### PR TITLE
Multisource support for ViewModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ myTweetViewModel.get("truncated_text") // => "I love bac…"
 {{ truncated_text }} <a href="#">View more</a>
 ```
 
+If your `computed_attributes` depend on multiple source models, you can initalize your `ViewModel` with a `source_models` attribute that contains a mapping of attribute to model pairs:
+
+```javascript
+var lhsModel = new Model({ value: 10 });
+var rhsModel = new Model({ value: 20 });
+
+var SumViewModel = Backbone.ViewModel.extend({
+    computed_attributes: {
+        sum : function() { return this.get("lhs").get("value") + this.get("rhs").get("value"); },
+    },
+});
+
+var sumModel = new SumViewModel({
+    source_models: {
+        lhs: lhsModel,
+        rhs: rhsModel,
+    },
+});
+```
+
+As with the single `source_model` approach the `computed_attributes` will be processed when the `ViewModel` is created, and when any of the `source_model`'s change.
+
+```javascript
+console.log(sumModel.get("sum"));  // Prints '30'.
+
+lhsModel.set({value: 5});
+
+console.log(sumModel.get("sum")); // Prints '25'.
+```
+
 ## Installation
 
 To install, include the `src/backbone-view-model.js` file in your HTML page, after Backbone and it's dependencies.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,70 @@
+// Karma configuration
+// Generated on Mon May 27 2013 14:38:04 GMT+1000 (EST)
+
+
+// base path, that will be used to resolve files and exclude
+basePath = '';
+
+
+// list of files / patterns to load in the browser
+files = [
+  QUNIT,
+  QUNIT_ADAPTER,
+  'test/lib/underscore-1.3.1.js',
+  'test/lib/jquery-1.4.2.min.js',
+  'test/lib/backbone-0.9.2.js',
+  'src/*.js',
+  'test/*.js'
+];
+
+
+// list of files to exclude
+exclude = [
+  
+];
+
+
+// test results reporter to use
+// possible values: 'dots', 'progress', 'junit'
+reporters = ['progress'];
+
+
+// web server port
+port = 9876;
+
+
+// cli runner port
+runnerPort = 9100;
+
+
+// enable / disable colors in the output (reporters and logs)
+colors = true;
+
+
+// level of logging
+// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+logLevel = LOG_INFO;
+
+
+// enable / disable watching file and executing tests whenever any file changes
+autoWatch = true;
+
+
+// Start these browsers, currently available:
+// - Chrome
+// - ChromeCanary
+// - Firefox
+// - Opera
+// - Safari (only Mac)
+// - PhantomJS
+// - IE (only Windows)
+browsers = ['Chrome'];
+
+
+// If browser does not capture in given timeout [ms], kill it
+captureTimeout = 60000;
+
+
+// Continuous Integration mode
+// if true, it capture browsers, run tests and exit
+singleRun = false;

--- a/src/view-model.js
+++ b/src/view-model.js
@@ -18,6 +18,8 @@ Backbone.ViewModel = (function(Backbone, _, undefined){
   _.extend(ViewModel.prototype, Model.prototype, {
 
     initializeViewModel: function(){
+      this.set(this.get("source_models"));
+      this.source_models = _.union(_.values(this.get('source_models')), (this.get('source_model') || []));
       this.setComputedAttributes();
       this.bindToChangesInSourceModel();
     },
@@ -29,9 +31,9 @@ Backbone.ViewModel = (function(Backbone, _, undefined){
     },
 
     bindToChangesInSourceModel: function(){
-      if(this.has("source_model")){
-        this.get("source_model").on("change", this.setComputedAttributes, this);
-      }
+      _.each(this.source_models, function(model) {
+          model.on("change", this.setComputedAttributes, this);
+      }, this);
     }
 
   });

--- a/test/view-model.test.js
+++ b/test/view-model.test.js
@@ -78,3 +78,58 @@ test("computed_attributes: Will be run on a change event of the 'source_model'",
 
   deepEqual(viewModel.get("welcome_message"), "Hi Ryan Bailey!", "welcome_message has been correctly updated on the viewModel");
 });
+
+test("computed_attributes: A ViewModel's attributes will be set from multiple 'source_models'", function(){
+  var Model = Backbone.ViewModel.extend({});
+
+  var ViewModel = Backbone.ViewModel.extend({
+    computed_attributes: {
+        message: function(){ return "Sum: " + (this.get("lhs").get("a") +
+                             this.get("rhs").get("b")); }
+    }
+  });
+
+  var lhs = new Model({ a: 10 });
+  var rhs = new Model({ b: 5 });
+
+  var viewModel = new ViewModel({source_models: {
+      lhs: lhs,
+      rhs: rhs,
+  }});
+
+  deepEqual(viewModel.get("message"), "Sum: 15", "attribute has been correctly derived from multiple source models");
+});
+
+test("computed_attributes: A ViewModel's attributes will be updated on change events on multiple 'source_models'", function(){
+  var Model = Backbone.ViewModel.extend({});
+
+  var ViewModel = Backbone.ViewModel.extend({
+    computed_attributes: {
+        message: function(){ return "Sum: " + (this.get("lhs").get("a") +
+                             this.get("rhs").get("b")); }
+    }
+  });
+
+  var lhs = new Model({ a: 10 });
+  var rhs = new Model({ b: 5 });
+
+  var viewModel = new ViewModel({source_models: {
+      lhs: lhs,
+      rhs: rhs,
+  }});
+
+  deepEqual(viewModel.get("message"), "Sum: 15", "attribute has been correctly derived from multiple source models");
+
+  lhs.set('a', 12);
+
+  deepEqual(viewModel.get("message"), "Sum: 17", "attribute has been correctly updated from first source model");
+
+  rhs.set('b', 7);
+
+  deepEqual(viewModel.get("message"), "Sum: 19", "attribute has been correctly updated from second source model");
+
+  rhs.set('a', 22);
+
+  deepEqual(viewModel.get("message"), "Sum: 19", "irrelevant atribute update become a noop");
+});
+


### PR DESCRIPTION
I hope you will consider accepting this new feature I added to your backbone-view-model.

It adds the ability to derive computed attributes from more than one model. The implementation is backwards compatible with the existing use of source_model merging it with a new `source_models` initialization option.

Passes all original tests unchanged, includes two new tests to cover new functionality.

Readme updated to document new feature.

Cheers,

Andrae Muys
